### PR TITLE
Fixed possible out-of-boundaries access to IP lookup_cache

### DIFF
--- a/src/parsers/ip.c
+++ b/src/parsers/ip.c
@@ -425,7 +425,7 @@ uint_fast32_t Parse_IP( const char *syslog_message, struct _Sagan_Lookup_Cache_E
 
                             /* If we've run to the end, we're done */
 
-                            if ( current_position > MAX_PARSE_IP )
+                            if ( current_position >= MAX_PARSE_IP )
                                 {
                                     break;
                                 }
@@ -461,7 +461,7 @@ uint_fast32_t Parse_IP( const char *syslog_message, struct _Sagan_Lookup_Cache_E
 
                             current_position++;
 
-                            if ( current_position > MAX_PARSE_IP )
+                            if ( current_position >= MAX_PARSE_IP )
                                 {
                                     break;
                                 }
@@ -513,7 +513,7 @@ uint_fast32_t Parse_IP( const char *syslog_message, struct _Sagan_Lookup_Cache_E
                             lookup_cache[current_position].status = 1;
                             current_position++;
 
-                            if ( current_position > MAX_PARSE_IP )
+                            if ( current_position >= MAX_PARSE_IP )
                                 {
                                     break;
                                 }
@@ -542,7 +542,7 @@ uint_fast32_t Parse_IP( const char *syslog_message, struct _Sagan_Lookup_Cache_E
 
                             current_position++;
 
-                            if ( current_position > MAX_PARSE_IP )
+                            if ( current_position >= MAX_PARSE_IP )
                                 {
                                     break;
                                 }
@@ -596,7 +596,7 @@ uint_fast32_t Parse_IP( const char *syslog_message, struct _Sagan_Lookup_Cache_E
 
                             /* If we've run to the end, we're done */
 
-                            if ( current_position > MAX_PARSE_IP )
+                            if ( current_position >= MAX_PARSE_IP )
                                 {
                                     break;
                                 }
@@ -627,7 +627,7 @@ uint_fast32_t Parse_IP( const char *syslog_message, struct _Sagan_Lookup_Cache_E
 
                             /* If we've run to the end, we're done */
 
-                            if ( current_position > MAX_PARSE_IP )
+                            if ( current_position >= MAX_PARSE_IP )
                                 {
                                     break;
                                 }
@@ -771,7 +771,7 @@ uint_fast32_t Parse_IP( const char *syslog_message, struct _Sagan_Lookup_Cache_E
 
                                     current_position++;
 
-                                    if ( current_position > MAX_PARSE_IP )
+                                    if ( current_position >= MAX_PARSE_IP )
                                         {
                                             break;
                                         }
@@ -835,7 +835,7 @@ uint_fast32_t Parse_IP( const char *syslog_message, struct _Sagan_Lookup_Cache_E
 
                                     current_position++;
 
-                                    if ( current_position > MAX_PARSE_IP )
+                                    if ( current_position >= MAX_PARSE_IP )
                                         {
                                             break;
                                         }
@@ -891,7 +891,7 @@ uint_fast32_t Parse_IP( const char *syslog_message, struct _Sagan_Lookup_Cache_E
 
                                     /* If we've run to the end, we're done */
 
-                                    if ( current_position > MAX_PARSE_IP )
+                                    if ( current_position >= MAX_PARSE_IP )
                                         {
                                             break;
                                         }
@@ -923,7 +923,7 @@ uint_fast32_t Parse_IP( const char *syslog_message, struct _Sagan_Lookup_Cache_E
 
                                     /* If we've run to the end, we're done */
 
-                                    if ( current_position > MAX_PARSE_IP )
+                                    if ( current_position >= MAX_PARSE_IP )
                                         {
                                             break;
                                         }


### PR DESCRIPTION
Hello, i've found that in some circumstances, when the log message contains many IP addresses, sagan randomly segfaulted or aborted. We identified that it's related to SentinelOne Cloud messages we are trying to analyze.
After some research, I found that the lookup cache is allocated as
```
lookup_cache = malloc(sizeof(struct _Sagan_Lookup_Cache_Entry) * MAX_PARSE_IP);
```
So the maximal possible index is (MAX_PARSE_IP - 1)
However, in module parsers/ip.c the loop break condition is
```
                            if ( current_position > MAX_PARSE_IP )
```
I believe it must be
```
                            if ( current_position >= MAX_PARSE_IP )
```
Thanks
Ilya

