### PR TITLE
Fix issue where including yaml file in sagan.yaml incorrectly truncates filename

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -773,8 +773,10 @@ void Var_To_Value(const char *in_str, char *str, size_t size)
             memset(tmp_result, 0, sizeof(tmp_result));
         }
 
+    if (isspace(tmp[strlen(tmp)-1])) {
+        tmp[strlen(tmp)-1] = 0;         /* Remove trailing space */
+    }
 
-    tmp[strlen(tmp)-1] = 0;		/* Remove trailing space */
     snprintf(str, size, "%s", tmp);
 
 }


### PR DESCRIPTION
Hi,

This fixes an issue with the `Var_To_Value` function in `src/util.c`. This function assumes that the last character of every `tmp` value passed to it is a space, which isn't always true. 

This can be reproduced using the latest 2.0.2 release with this minimal example of `sagan.yaml`:
```
%YAML 1.1
---

#  ,-._,-.  Sagan configuration file [http://sagan.quadrantsec.com]
#  \/)"(\/  Champ Clark III & The Quadrant Infosec Team: http://quadrantsec.com
#   (_o_)   Copyright (C) 2009-2019 Quadrant Information Security., et al.
#   /   \/)
#  (|| ||)
#   oo-oo

include: "01-vars.yaml"
```

causes Sagan to remove the last character of the filename, resulting in it trying to include `01-vars.yam`:

```
sagan -f sagan.yaml

[*] Sagan's PID is 34208
[*] Loading included file '01-vars.yam'.
[E] [config-yaml.c, line 342] Failed to open the configuration file '01-vars.yam' Abort!
```


This PR adds a check to the offending line in `Var_To_Value` to ensure that the last character is actually a space before removing it.