### PR TITLE
Only run sanity checks once all YAML parsing is completed

### DIFF
--- a/src/config-yaml.c
+++ b/src/config-yaml.c
@@ -99,7 +99,7 @@ extern bool reload_rules;
 
 #ifdef HAVE_LIBYAML
 
-void Load_YAML_Config( char *yaml_file )
+void Load_YAML_Config( char *yaml_file, bool is_root_config )
 {
 
     struct stat filecheck;
@@ -578,7 +578,7 @@ void Load_YAML_Config( char *yaml_file )
 
                                     Var_To_Value(value, tmp, sizeof(tmp));
                                     Sagan_Log(NORMAL, "Loading included file '%s'.", tmp);
-                                    Load_YAML_Config(tmp);
+                                    Load_YAML_Config(tmp, false);
 
                                     toggle = 1;
 
@@ -2747,6 +2747,11 @@ void Load_YAML_Config( char *yaml_file )
     /**********************/
     /* Sanity checks here */
     /**********************/
+
+    // Don't perform sanity checks if not root config
+    if (!is_root_config) {
+        return;
+    }
 
     /* Check rules for duplicate sid.  We can't have that! */
 

--- a/src/config-yaml.h
+++ b/src/config-yaml.h
@@ -76,6 +76,6 @@
 #define		YAML_OUTPUT_ALERT		306
 #define		YAML_OUTPUT_EVE			307
 
-void Load_YAML_Config( char * );
+void Load_YAML_Config( char *, bool );
 
 #endif

--- a/src/sagan.c
+++ b/src/sagan.c
@@ -729,7 +729,7 @@ int main(int argc, char **argv)
 #endif
 
     pthread_mutex_lock(&SaganRulesLoadedMutex);
-    (void)Load_YAML_Config(config->sagan_config);
+    (void)Load_YAML_Config(config->sagan_config, true);
 
     /* If we are in "test" mode, we can stop here */
 

--- a/src/signal-handler.c
+++ b/src/signal-handler.c
@@ -411,7 +411,7 @@ void Sig_Handler( void )
                     /************************************************************/
 
                     pthread_mutex_lock(&SaganRulesLoadedMutex);
-                    Load_YAML_Config(config->sagan_config);	/* <- RELOAD */
+                    Load_YAML_Config(config->sagan_config, true);	/* <- RELOAD */
                     pthread_mutex_unlock(&SaganRulesLoadedMutex);
 
                     /************************************************************/


### PR DESCRIPTION
Fixes #83 

This adds context to the `Load_YAML_Config` function so it is aware if the `yaml_file` it is currently processing is the root configuration (`is_root_config == true`) or rather an included sub-file (`is_root_config == false`).

Doing so allows the sanity checks to only be performed once the root configuration has completed processing, rather than for each individual configuration file