### PR TITLE
Fix mismatch in liblognorm IP validation

### DIFF
--- a/src/liblognormalize.c
+++ b/src/liblognormalize.c
@@ -139,7 +139,7 @@ void Normalize_Liblognorm( struct _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL )
             if ( !Is_IP(tmp, IPv4) && !Is_IP(tmp, IPv6) )
                 {
 
-                    SaganProcSyslog_LOCAL->dst_ip[0] = '\0';
+                    SaganProcSyslog_LOCAL->src_ip[0] = '\0';
                     SaganProcSyslog_LOCAL->ip_src_is_valid = false;
                     json_object_put(json_norm);
                     return;
@@ -177,7 +177,7 @@ void Normalize_Liblognorm( struct _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL )
                 }
 
             strlcpy(SaganProcSyslog_LOCAL->dst_ip, tmp, MAXIP);
-            IP2Bit(SaganProcSyslog_LOCAL->src_ip, SaganProcSyslog_LOCAL->ip_src_bits);
+            IP2Bit(SaganProcSyslog_LOCAL->dst_ip, SaganProcSyslog_LOCAL->ip_dst_bits);
 
             if ( is_notlocalhost( SaganProcSyslog_LOCAL->ip_dst_bits ) )
                 {


### PR DESCRIPTION
The routine in loglognormalize.c used for handling invalid IP addresses was unsetting dst_ip if src_ip was invalid.  

```
if ( !Is_IP(tmp, IPv4) && !Is_IP(tmp, IPv6) )
                {

                    SaganProcSyslog_LOCAL->dst_ip[0] = '\0';
                    SaganProcSyslog_LOCAL->ip_src_is_valid = false;
```
The IP2Bit call in the dst_ip validation of liblognormalize.c was processing the src_ip value not the dst_ip value.  

```
      strlcpy(SaganProcSyslog_LOCAL->dst_ip, tmp, MAXIP);
            IP2Bit(SaganProcSyslog_LOCAL->src_ip, SaganProcSyslog_LOCAL->ip_src_bits);
```
