### PR TITLE
Removed redundant and incomplete Credits section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,5 @@ Credits
 -------
 
 A lot of people have invested time in Sagan.  We list people who have contributed in our source code tree. 
-See the https://github.com/quadrantsec/sagan/blob/main/src/credits.c source f
-
-Credits
--------
-
-A lot of people have invested time in Sagan.  We list people who have contributed in our source code tree. 
 See the https://github.com/quadrantsec/sagan/blob/main/src/credits.c source file.
 


### PR DESCRIPTION
Was checking out the github repo based on a linkedin job posting and saw this minor issue.