### PR TITLE
Update sagan-rules clone link in documentation

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -393,7 +393,7 @@ Create a "sagan" user and related directories::
 Checkout the "sagan-rules" repository into ``/usr/local/etc/sagan-rules``::
 
     cd /usr/local/etc
-    sudo git clone https://github.com/beave/sagan-rules
+    sudo git clone https://github.com/quadrantsec/sagan-rules.git
 
 To test, run ``sagan --debug syslog,engine`` as the root user.  It will
 switch to the sagan user when ready, and remain running in the foreground.


### PR DESCRIPTION
Received an error when running the following command during installation:

```
steve:~sagan$ sudo sagan --debug syslog,engine
[*] Sagan's PID is 10904
[*] Loading classifications.conf file. [/usr/local/etc/sagan-rules/classification.config]
[*] 53 classifications loaded
[*] Loading references.conf file. [/usr/local/etc/sagan-rules/reference.config]
[*] 6 references loaded.
[*] Loading protocol map file. [/usr/local/etc/sagan-rules/protocol.map]
[E] [protocol-map.c, line 104] 'type' not specified at line 2
```

Updated the sagan-rules github link to prevent issues like these from showing up again:
#44 
#71 

