### PR TITLE
Add support for libasan and fix heap-buffer-overflow

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,6 +100,12 @@ AC_ARG_ENABLE(syslog,
   [ SYSLOG="yes" ]
 )
 
+AC_ARG_ENABLE(asan,
+  [  --enable-asan           Enable address sanitizer.],
+  [ ASAN="$enableval"],
+  [ ASAN="no" ]
+)
+
 AC_ARG_ENABLE(system-strstr,
   [  --enable-system-strstr  Enable system strstr.],
   [ SYSSTRSTR="$enableval"],
@@ -646,6 +652,10 @@ This library is used for Sagan's 'offload' support. To disable this feature use 
         AC_DEFINE(WITH_OFFLOAD, 1, With Offload)
         fi
 
+if test "$ASAN" = "yes"; then
+    AC_MSG_RESULT([------- Address Sanitize enabled -------])
+    CFLAGS="$CFLAGS -fsanitize=address"
+fi
 
 test "x$prefix" = x. || test "x$prefix" = xNONE && prefix=/usr/local
 AC_DEFINE_UNQUOTED(CONFIG_FILE_PATH, "`eval echo "${sysconfdir}/sagan.yaml"`", [Sagan configuration file]) 

--- a/src/config-yaml.c
+++ b/src/config-yaml.c
@@ -419,6 +419,15 @@ void Load_YAML_Config( char *yaml_file, bool is_root_config )
                         {
                             Sagan_Log(DEBUG, "[%s, line %d] YAML_MAPPING_END_EVENT", __FILE__, __LINE__);
                         }
+
+                    /* Fix heap-buffer-overflow error */
+                    var = (_SaganVar *) realloc(var, (counters->var_count+1) * sizeof(_SaganVar));
+                    if ( var == NULL )
+                    {
+                        Sagan_Log(ERROR, "[%s, line %d] Failed to reallocate memory for var. Abort!", __FILE__, __LINE__);
+                    }
+
+                    memset(&var[counters->var_count], 0, sizeof(struct _SaganVar));
                 }
 
             else if ( event.type == YAML_SCALAR_EVENT )


### PR DESCRIPTION
Hi,
I've been coping with several issues with unexpected crashes of the Sagan project. I've been able to figure out it's caused by the heap buffer overflow as discovered by libasan flags used in the compilation.

This is the patch to support libasan for sagan and also fix detected heap-buffer-overflow while reading YAML configuration file.

Signed-off-by: Michal Novotny < michal.novotny@greycortex.com >